### PR TITLE
🐳 Add PHP extension intl to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN set -eux; \
         opcache \
         zip \
         bcmath \
+        intl \
     ;
 
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser


### PR DESCRIPTION
## 🔍 Samenvatting

Deze PR voegt de PHP extentie `intl` toe aan de Dockerfile. Dit lost de foutmelding op in symfony die is ontstaan na een update van `doctine/doctrine-bundle`: `Please install the "intl" PHP extension for best performance.`

Zie:
- https://github.com/brixion/gopact-backend/pull/106
- https://github.com/brixion/striking-backend/actions/runs/17671385064/job/50223758439

## ✅ Checklist

- [x] Code is lokaal getest
- [ ] Tests zijn toegevoegd/aangepast
- [ ] Documentatie bijgewerkt (indien nodig)
