### PR TITLE
🧩 Update boilerplate other

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,6 @@
 ---
+# This file is managed by brixion/boilerplate.
+# Do not edit it in this repository; changes will be overwritten on the next sync.
 version: 2
 updates:
   - package-ecosystem: github-actions

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,4 +1,6 @@
 ---
+# This file is managed by brixion/boilerplate.
+# Do not edit it in this repository; changes will be overwritten on the next sync.
 name: Dependabot
 
 on:

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,5 +1,6 @@
 ---
-
+# This file is managed by brixion/boilerplate.
+# Do not edit it in this repository; changes will be overwritten on the next sync.
 name: Label Sync
 
 on:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,5 +1,6 @@
 ---
-
+# This file is managed by brixion/boilerplate.
+# Do not edit it in this repository; changes will be overwritten on the next sync.
 name: PR Validation
 
 on:

--- a/.github/workflows/repo-quality-checks.yml
+++ b/.github/workflows/repo-quality-checks.yml
@@ -1,5 +1,6 @@
 ---
-
+# This file is managed by brixion/boilerplate.
+# Do not edit it in this repository; changes will be overwritten on the next sync.
 name: Repo Quality Checks
 
 on:


### PR DESCRIPTION
## 🔎 Samenvatting

Deze PR markeert alle gesyncte YAML-bestanden als boilerplate-managed, zodat ze in productrepos niet handmatig worden aangepast. Daarnaast komen de -templates eindelijk onder , gelijk aan backend en frontend. Zonder die map belanden Dependabot, release-config en CI op de verkeerde plek in Symfony-repos.

## 📝 Beschrijving

- Toegevoegd: do-not-edit-comment bovenaan alle YAML in , ,  en .
- Aangepast: witregel na  overal verwijderd, inclusief de eigen workflows in .
- Verplaatst:  templates van de root naar ,  en .
- Gelijkgetrokken: changelog-categorieën van  met de alignment van backend ( en samengevoegde UI/UX).

---

## 🧩 Boilerplate update

**Originele auteur**: @rickyheijnen
**Originele PR**: [#39](https://github.com/brixion/boilerplate/pull/39)

---

> 🤖 Deze PR is automatisch gemaakt door de boilerplate synchronisatie workflow