### PR TITLE
🧩 Update boilerplate other

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,5 +13,5 @@ permissions:
 jobs:
   automate:
     name: Automate
-    uses: brixion/workflows/.github/workflows/dependabot-automate.yml@main
+    uses: brixion/workflows/.github/workflows/reusable-dependabot-automate.yml@main
     secrets: inherit

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -13,4 +13,4 @@ permissions:
 jobs:
   validate:
     name: Validate PR
-    uses: brixion/workflows/.github/workflows/pr-validation.yml@main
+    uses: brixion/workflows/.github/workflows/reusable-pr-validation.yml@main

--- a/.github/workflows/repo-quality-checks.yml
+++ b/.github/workflows/repo-quality-checks.yml
@@ -13,4 +13,4 @@ permissions:
 jobs:
   lint:
     name: Lint
-    uses: brixion/workflows/.github/workflows/lint.yml@main
+    uses: brixion/workflows/.github/workflows/reusable-lint.yml@main


### PR DESCRIPTION
## 🔎 Samenvatting

Deze PR laat alle boilerplate-callers wijzen naar de  workflows in , die sinds #57 op  staan. Daarmee botst  niet meer met de reusable implementatie, en is het onderscheid caller vs reusable overal hetzelfde.

## 📝 Beschrijving

- Aangepast:  in , type-overlays (, , ) en de root-CI van deze repo.
- Nieuwe paden: , , , , .

---

## 🧩 Boilerplate update

**Originele auteur**: @rickyheijnen
**Originele PR**: [#43](https://github.com/brixion/boilerplate/pull/43)

---

> 🤖 Deze PR is automatisch gemaakt door de boilerplate synchronisatie workflow